### PR TITLE
migrate proc-macro-error to maintained version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ syn = { version = "1.0.73", features = ["full"] }
 proc-macro2 = "1.0.27"
 quote = "1.0.9"
 Inflector = { version="0.11.4", default-features=false }
-proc-macro-error = "1.0.4"
+proc-macro-error2 = "2.0.1"
 check_keyword = "0.1.1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ use proc_macro::TokenStream;
 use syn::{Ident, parse_macro_input, ItemEnum, Fields};
 use quote::{quote, format_ident};
 use inflector::Inflector;
-use proc_macro_error::{proc_macro_error, emit_error, abort};
+use proc_macro_error2::{proc_macro_error, emit_error, abort};
 use check_keyword::CheckKeyword;
 
 /// Stores basic information about variants.


### PR DESCRIPTION
https://github.com/rust-lang/docs.rs/issues/2595

Seems to suggest that proc-macro-error2 is the correct replacement. It has similar usage on crates.io and seems to have active development. Tests pass. I also opened an issue against my proposed replacement to clarify its relationship to the original dependency: https://github.com/GnomedDev/proc-macro-error-2/issues/10